### PR TITLE
[ALD-24] Solve bug where sometimes storage is 0GB

### DIFF
--- a/src/LaptopDetailsPage/LaptopDetails.js
+++ b/src/LaptopDetailsPage/LaptopDetails.js
@@ -128,7 +128,7 @@ const LaptopDetails = (props) => {
               </p>
               <p>
                 <strong>Storage: </strong>{" "}
-                {`${laptopDetail.laptop.storageOne} GB`}
+                {`${laptopDetail.laptop.totalStorage} GB`}
               </p>
               <p>
                 <strong>Graphics: </strong> {laptopDetail.laptop.graphics}

--- a/src/ResultPage/Result.js
+++ b/src/ResultPage/Result.js
@@ -86,8 +86,7 @@ class Result extends React.Component {
     }
     axios
       .post("https://api.propicks.id/v1/recommendation", reqBody)
-      // axios
-      //   .post("http://127.0.0.1:8080/v1/recommendation", reqBody)
+      //  .post("http://127.0.0.1:8080/v1/recommendation", reqBody)
       .then((res) => {
         this.setState({
           recommendations: res,

--- a/src/components/FeedbackModal.js
+++ b/src/components/FeedbackModal.js
@@ -91,7 +91,7 @@ const FeedbackModal = (props) => {
     if (feedback === false && feedbackInput === "" && feedbackStar === 0) {
       setTimeout(() => {
         handleShowFeedback();
-      }, 20000);
+      }, 25000);
     }
 
     if (showToast) {

--- a/src/components/result/LaptopList.js
+++ b/src/components/result/LaptopList.js
@@ -127,7 +127,7 @@ const LaptopList = (props) => {
                     <strong>RAM: </strong> {`${item.ram} GB`}
                   </p>
                   <p>
-                    <strong>Storage: </strong> {`${item.storageOne} GB`}
+                    <strong>Storage: </strong> {`${item.totalStorage} GB`}
                   </p>
                   <p>
                     <strong>Graphics: </strong> {item.graphics}


### PR DESCRIPTION
### Description
- Dari dulu ternyata FE cman show value storageOne untuk storage nya. Padahal stiap laptop itu pnya storageOne (SSD) dan storageTwo (HDD). Makanya tiap kali ada laptop yang HDD, storagenya akan displayed as 0 di propicks
- Created a fix both dari BE dan FE. BE jadi ngereturn extra field namanya "totalStorage" which is basically storageOne + storageTwo, trus FE tnggal pake itu

### Testing
Lupa screenshot pas testing memori yang HDDnya, tapi local test successful